### PR TITLE
Add To DEFAULT_TRACKING_PARAMETERS

### DIFF
--- a/Extension/lib/utils/user-settings.js
+++ b/Extension/lib/utils/user-settings.js
@@ -27,7 +27,7 @@ adguard.settings = (function (adguard) {
     const DEFAULT_FILTERS_UPDATE_PERIOD_MS = 48 * 60 * 60 * 1000;
     const DEFAULT_FIRST_PARTY_COOKIES_SELF_DESTRUCT_MIN = 4320;
     const DEFAULT_THIRD_PARTY_COOKIES_SELF_DESTRUCT_MIN = 2880;
-    const DEFAULT_TRACKING_PARAMETERS = 'utm_source,utm_medium,utm_term,utm_campaign,utm_content,utm_name,utm_cid,utm_reader,utm_viz_id,utm_pubreferrer,utm_swu';
+    const DEFAULT_TRACKING_PARAMETERS = 'utm_source,utm_medium,utm_term,utm_campaign,utm_content,utm_name,utm_cid,utm_reader,utm_viz_id,utm_pubreferrer,utm_swu,utm_referrer,utm_social,utm_social-type,utm_place,utm_userid,utm_channel,fb_action_ids,fb_action_types,fb_ref,fb_source';
 
     var settings = {
         DISABLE_DETECT_FILTERS: 'detect-filters-disabled',


### PR DESCRIPTION
Added
`,utm_referrer,utm_social,utm_social-type,utm_place,utm_userid,utm_channel,fb_action_ids,fb_action_types,fb_ref,fb_source`

This will strip more tracking tokens Google as well as add stripping for Facebook tokens.