### PR TITLE
Add devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Adguard",
+  "dockerComposeFile": "../docker-compose.yaml",
+  "service": "adguard",
+  "workspaceFolder": "/adguard/${localWorkspaceFolderBasename}",
+  "remoteUser": "node"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:18
+
+RUN apt-get update && apt-get install fish mc vim curl sudo tmux -y && \
+    echo "fish" >>~/.bashrc
+
+RUN echo 'root:123' | chpasswd
+RUN echo 'node:123' | chpasswd
+
+RUN sudo usermod -a -G sudo node
+
+USER node
+
+# customize tmux
+RUN cd && \
+    git clone https://github.com/gpakosz/.tmux.git && \
+    ln -s -f .tmux/.tmux.conf && \
+    cp .tmux/.tmux.conf.local .
+
+# upd configs for cli tools
+RUN echo "fish" >>~/.bashrc
+RUN mkdir -p ~/.config/fish
+RUN echo "alias tmux='tmux -2'" >>~/.config/fish/config.fish
+RUN echo "set -U fish_prompt_pwd_dir_length 0" >>~/.config/fish/config.fish
+
+# install lazygit
+RUN wget https://github.com/jesseduffield/lazygit/releases/download/v$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')/lazygit_$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')_Linux_32-bit.tar.gz -P ~/.lazygit/
+RUN tar -xf ~/.lazygit/lazygit_$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')_Linux_32-bit.tar.gz -C ~/.lazygit/
+RUN echo "alias lazygit='~/.lazygit/lazygit'" >>~/.config/fish/config.fish
+RUN echo "alias lz='~/.lazygit/lazygit'" >>~/.config/fish/config.fish
+RUN git config --global core.autocrlf true
+RUN git config --global --add safe.directory '*'
+
+WORKDIR /app
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: "3.1"
+
+services:
+  adguard:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    container_name: adguard
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    volumes:
+      - ..:/adguard:cached
+    tty: true
+    stdin_open: true
+    restart: on-failure 
+    command: sleep infinity
+   


### PR DESCRIPTION
Add configs for devcontainer.
So  no more need to install node, or change it's version on your machine.

Install [ms-vscode-remote.remote-containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and run "reopen in container"

Benefits - everyone has the same linux environment(ubuntu), cli tools that are guaranteed to work.
Available cli apps: fish, mc, vim, curl, sudo, tmux, lazygit