### PR TITLE
fix: extension does not initialize on startup

### DIFF
--- a/Extension/src/background/index.ts
+++ b/Extension/src/background/index.ts
@@ -19,6 +19,8 @@ import browser from 'webextension-polyfill';
 
 import { App } from 'app';
 
-// initialize background services
+// Initialize background services.
+// Initialization is deferred to `onStartup` and `onInstalled` events
+// because the extension uses a non-persistent background page model.
 browser.runtime.onStartup.addListener(App.init);
 browser.runtime.onInstalled.addListener(App.init);

--- a/Extension/src/background/index.ts
+++ b/Extension/src/background/index.ts
@@ -15,7 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with AdGuard Browser Extension. If not, see <http://www.gnu.org/licenses/>.
  */
+import browser from 'webextension-polyfill';
+
 import { App } from 'app';
 
 // initialize background services
-App.init();
+browser.runtime.onStartup.addListener(App.init);
+browser.runtime.onInstalled.addListener(App.init);


### PR DESCRIPTION
Persistent of background page is set to [false](https://github.com/AdguardTeam/AdguardBrowserExtension/blob/aaf9ff758ba7387ef41b9b7d8c703184b94d9b79/tools/bundle/firefox/manifest.firefox.ts#L45) in extension manifest on Firefox. 

Others should be fine with this modification.

related #3176