### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/Extension/assets/css/fonts.css
+++ b/Extension/assets/css/fonts.css
@@ -1,21 +1,21 @@
 @charset "UTF-8";
 @font-face {
     font-family: 'Open Sans';
-    url('../fonts/opensans-regular-webfont.woff2') format('woff2'),
+    src: url('../fonts/opensans-regular-webfont.woff2') format('woff2');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Open Sans';
-    url('../fonts/opensans-semibold-webfont.woff2') format('woff2'),
+    src: url('../fonts/opensans-semibold-webfont.woff2') format('woff2');
     font-weight: 600;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Open Sans';
-    url('../fonts/opensans-bold-webfont.woff2') format('woff2'),
+    src: url('../fonts/opensans-bold-webfont.woff2') format('woff2');
     font-weight: bold;
     font-style: normal;
 }

--- a/Extension/pages/popup/index.html
+++ b/Extension/pages/popup/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset="UTF-8">

--- a/Extension/pages/popup/index.html
+++ b/Extension/pages/popup/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html>
 
 <head>
     <meta charset="UTF-8">

--- a/Extension/pages/popup/index.html
+++ b/Extension/pages/popup/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>AdGuard Popup</title>
+    <title>Popup</title>
 </head>
 
 <body>

--- a/Extension/pages/popup/index.html
+++ b/Extension/pages/popup/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Popup</title>
+    <title>AdGuard Popup</title>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `Extension/assets/css/fonts.css:L2`

The first three `@font-face` blocks are malformed: they contain bare `url(...)` lines instead of a `src:` declaration. As written, these rules are invalid CSS, so browsers will ignore them and the Open Sans variants will never be registered. This can cause fallback fonts to render throughout the UI.

## Solution

Rewrite each block to use a valid `src:` property, for example `src: url('../fonts/opensans-regular-webfont.woff2') format('woff2');`, and keep each font-weight/style in its own properly formed `@font-face` rule.

## Changes

- `Extension/assets/css/fonts.css` (modified)
- `Extension/pages/popup/index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced